### PR TITLE
feat: modal context 추가

### DIFF
--- a/apps/pick-learn/src/app/layout.tsx
+++ b/apps/pick-learn/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { dmSans } from '@/shared/assets/fonts';
+import { ModalProvider } from '@/shared/model/modal/ModalContext';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -47,7 +48,9 @@ export default function RootLayout({
 }) {
     return (
         <html lang='ko-KR'>
-            <body className={dmSans.className}>{children}</body>
+            <body className={dmSans.className}>
+                <ModalProvider>{children}</ModalProvider>
+            </body>
         </html>
     );
 }

--- a/apps/pick-learn/src/shared/model/modal/ModalContext.tsx
+++ b/apps/pick-learn/src/shared/model/modal/ModalContext.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+import type { ModalContextType, ModalProviderProps } from './types';
+import { Modal } from '@repo/ui/components/base/modal';
+
+const ModalContext = createContext<ModalContextType>({} as ModalContextType);
+
+export function ModalProvider({ children }: ModalProviderProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [content, setContent] = useState<ReactNode | null>(null);
+
+    const openModal = (content: ReactNode) => {
+        setContent(content);
+        setIsOpen(true);
+    };
+
+    const closeModal = () => {
+        setContent(null);
+        setIsOpen(false);
+    };
+
+    return (
+        <ModalContext.Provider value={{ isOpen, openModal, closeModal }}>
+            {children}
+            <Modal open={isOpen} onClose={closeModal}>
+                {content}
+            </Modal>
+        </ModalContext.Provider>
+    );
+}
+
+export function useModalContext() {
+    const context = useContext(ModalContext);
+    if (context === undefined) {
+        throw new Error('useModal must be used within a ModalProvider');
+    }
+    return context;
+}

--- a/apps/pick-learn/src/shared/model/modal/types.ts
+++ b/apps/pick-learn/src/shared/model/modal/types.ts
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 
 export type ModalContextType = {
     isOpen: boolean;
-    // content: ReactNode | null;
     openModal: (content: ReactNode) => void;
     closeModal: () => void;
 };

--- a/apps/pick-learn/src/shared/model/modal/types.ts
+++ b/apps/pick-learn/src/shared/model/modal/types.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+export type ModalContextType = {
+    isOpen: boolean;
+    // content: ReactNode | null;
+    openModal: (content: ReactNode) => void;
+    closeModal: () => void;
+};
+
+export type ModalProviderProps = {
+    children: ReactNode;
+};

--- a/packages/ui/src/styles/default.css
+++ b/packages/ui/src/styles/default.css
@@ -178,15 +178,13 @@
 @layer utilities {
     @keyframes card-slide-up {
         0% {
-            transform: translate(0, 500%);
-        }
-
-        70% {
-            transform: translate(0, -5%);
+            transform: translate3d(0, 30%, 0);
+            opacity: 0;
         }
 
         100% {
-            transform: translate(0, 0);
+            transform: translate3d(0, 0, 0);
+            opacity: 1;
         }
     }
 
@@ -212,7 +210,6 @@
     .animate-card-slide-up {
         animation: card-slide-up 0.4s ease-in-out;
     }
-
     .animate-bottom-sheet-slide-up {
         animation: bottom-sheet-slide-up 0.4s ease-in-out;
     }


### PR DESCRIPTION
# 🚀 What type of PR is this?

> 괄호안에 x를 작성하면 체크 상태가 됩니다. Preview를 보시고 제대로 적용되었는지 확인해주세요.
> ex) [x] -> O [ x], [ x ], [x ] -> X -->

- [x] ✨ New Features (새로운 기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [ ] 🛠️ Refactoring (리팩토링)
- [ ] 📝 Documentation Update (문서 수정)
- [ ] 🚀 Performance Improvement (성능 개선)
- [ ] ⚡ ETC (기타 - 이곳에 작성해주세요)
- [ ] ⏳ test (테스트)

# 🔗 Related Issue

> 해결하는 이슈 번호를 입력하면 PR이 머지될 때 자동으로 해당 이슈가 닫힙니다.
> ex) Closes #이슈번호 or Fixes #이슈번호 or Resolves #이슈번호

- #16 

## 💡 Description

> 변경된 내용을 설명해주세요.

- /apps/pick-learn에 modal context 전역 상태 관리 로직 추가

## 📌 Changes

> 어떤 부분이 변경되었나요?

- @repo/ui에 위치한 Modal 컴포넌트를 application에서 전역으로 사용할 수 있도록 modal context 추가
- modal context로 `isOpen`, `openModal`, `closeModal` 상태 공유
- `layout.tsx`에 ModalProvider 추가
- ModalProvider 내부에 @repo/ui에 위치한 Modal 컴포넌트 추가
- `default.css`에 모달 애니메이션 css 수정
- 사용 예시
```typescript
// 예시
'use client';

import { useModalContext } from '@/shared/model/modal/ModalContext';
import { Button } from '@repo/ui/components/base/button';

function TestModal() {
    const { closeModal } = useModalContext();

    return (
        <div className='p-4'>
            <h1>Test Modal</h1>
            <Button onClick={closeModal}>close</Button>
        </div>
    );
}

export default function page() {
    const { openModal } = useModalContext();

    return (
        <main className='max-w-3xl mx-auto px-4 py-8'>
            <h1 className='text-2xl font-bold mb-4'>Home Page</h1>
            <Button onClick={() => openModal(<TestModal />)}>Open Modal</Button>
        </main>
    );
}

```

## 📸 Screenshot (선택 사항)
> 변경 사항을 보여주는 스크린샷을 첨부해주세요.

![image](https://github.com/user-attachments/assets/a5f3b05c-3948-4dea-b7ef-9e81dd6767ec)

## 🔗 Reference

> 참고할 만한 자료, 이슈 또는 관련 PR을 연결해주세요.

-
